### PR TITLE
Renames the script to `ship` after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ you. An easy one-line install is available through [sinister][]:
 
 [sinister]: https://github.com/jamesqo/sinister
 
-	sh <(curl -sSL https://git.io/fjjvu) --name ship --local --chmod 755 --url https://git.io/fjhO5
+	sh <(curl -sSL https://git.io/sinister) --name ship --local --chmod 755 --url https://git.io/fjhO5
 
 The above one-liner will install the script just for the current user. If you
 want it globally, remove `--local` option.


### PR DESCRIPTION
Sinister prefers the URI resource name which, in this case, is a short
name. Passing the `--name` parameters should work but there is a bug on
jamesqo/sinister#5 that prefers the *URI resource name* rather than the
parameters given - which means this waits the upstream merge to be
merged.

Closes #2