### PR TITLE
fix the git command being searched in upper-case

### DIFF
--- a/ship
+++ b/ship
@@ -20,7 +20,7 @@ OPTION_FORCE_RECREATION=""
 OPTION_SHELL_TEST="bash ash"
 
 ENTRYPOINT="main"
-GIT=$(command -v GIT)
+GIT=$(command -v git)
 DOCKER=$(command -v docker)
 
 if [ -n "$DEBUG" ] 


### PR DESCRIPTION
On my Ubuntu machine `command -v GIT` finds nothing, while `command -v git` finds the `git` executable perfectly well.